### PR TITLE
Bug fix: go_objects should be able to implement interfaces

### DIFF
--- a/glib/go_object.go
+++ b/glib/go_object.go
@@ -175,7 +175,7 @@ func RegisterGoType(name string, goObject interface{}, extends Extendable, inter
 	// Register class data if the object implements a GoObjectSubclass
 	var cd *classData
 	if object, ok := goObject.(GoObjectSubclass); ok {
-		cd := &classData{
+		cd = &classData{
 			elem: object,
 			ext:  extends,
 		}
@@ -201,7 +201,7 @@ func RegisterGoType(name string, goObject interface{}, extends Extendable, inter
 	)
 
 	// Add interfaces if the go object implements a GoObjectSubclass
-	if _, ok := goObject.(GoObjectSubclass); ok {
+	if cd != nil {
 		for _, iface := range interfaces {
 			gofuncPtr := gopointer.Save(&interfaceData{
 				iface:     iface,


### PR DESCRIPTION
There was a tiny typo that meant class data was not attached to the interface callback objects.

When constructing Go Objects that implement one or more interfaces this would result in a nil pointer exception within goInterfaceInit.

Discovered whilst using go-gst:

```
  gst.RegisterElement(
    plugin,
    elementName,
    gst.RankNone,
    &httpSrc,
    base.ExtendsBaseSrc,
    gst.InterfaceURIHandler,
  )
```