### PR TITLE
Copy the return value using g_value_copy in goMarshal to avoid double free and invalid memory reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
+Deprecated. Use [go-glib](https://github.com/go-gst/go-glib) instead.
+
 # go-glib
 Glib bindings for go. Originally forked from gotk3/gotk3.

--- a/glib/glib.go
+++ b/glib/glib.go
@@ -274,7 +274,7 @@ func goMarshal(closure *C.GClosure, retValue *C.GValue,
 			fmt.Fprintf(os.Stderr,
 				"cannot save callback return value: %v", err)
 		} else {
-			*retValue = *g.native()
+			C.g_value_copy(g.native(), retValue)
 		}
 	}
 }

--- a/glib/gparamspec.go
+++ b/glib/gparamspec.go
@@ -32,6 +32,11 @@ func ToParamSpec(paramspec unsafe.Pointer) *ParamSpec {
 	}
 }
 
+// newParamSpec creates a new ParamSpec from a GParamSpec pointer.
+func newParamSpec(p *C.GParamSpec) *ParamSpec {
+	return &ParamSpec{paramSpec: p}
+}
+
 // Name returns the name of this parameter.
 func (p *ParamSpec) Name() string {
 	return C.GoString(C.g_param_spec_get_name(p.paramSpec))


### PR DESCRIPTION
This is a PR that attempt to fix a double free and invalid memory access when registering a signal that returns a GValue. The Go signal marshaller currently does a shallow copy of the GValue (`g`) created from the native Go type into the returned GValue (`retValue`). If the GValue backs a type that requires deallocation (such as a string), this inner value payload will be deallocated twice, once when `g` gets deallocated, and once when `retValue` does. The PR suggests calling `g_value_copy` to do a deep copy of the GValue instead. 